### PR TITLE
cover: Fix build for 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.7
   - 1.8
   - 1.9
+  - "1.10"
   - tip
 script:
   - cd examples/calc && ./run-tests.sh

--- a/pkg/cover/cover.go
+++ b/pkg/cover/cover.go
@@ -47,6 +47,8 @@ type dummyTestDeps func(pat, str string) (bool, error)
 func (d dummyTestDeps) MatchString(pat, str string) (bool, error)   { return false, nil }
 func (d dummyTestDeps) StartCPUProfile(io.Writer) error             { return nil }
 func (d dummyTestDeps) StopCPUProfile()                             {}
+func (f dummyTestDeps) StartTestLog(w io.Writer)                    {}
+func (f dummyTestDeps) StopTestLog() error                          { return nil }
 func (d dummyTestDeps) WriteHeapProfile(io.Writer) error            { return nil }
 func (d dummyTestDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
 func (f dummyTestDeps) ImportPath() string                          { return "" }


### PR DESCRIPTION
golang 1.10 requires a `TestDeps` to implement `StartTestLog()`
and `StopTestLog()`.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>