### PR TITLE
Go 1.16 fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.8
   - 1.9
   - "1.10"
+  - 1.16
   - tip
 script:
   - cd examples/calc && ./run-tests.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ One may even want to gather coverage for a running service in production to get
 hot paths or detect unused part of an application.
 
 I call this coverage-instrumented go binaries. The full story can be read in
-this [blog post](http://damien.lespiau.name/2017/05/building-and-using-coverage.html).
+this [blog post](https://damien.lespiau.name/posts/2017-01-29-building-and-using-coverage-instrumented-programs-with-go/).
+
 
 This repository contains support packages and tools to produce
 and use coverage-instrumented Go programs.

--- a/pkg/cover/cover.go
+++ b/pkg/cover/cover.go
@@ -52,6 +52,7 @@ func (f dummyTestDeps) StopTestLog() error                          { return nil
 func (d dummyTestDeps) WriteHeapProfile(io.Writer) error            { return nil }
 func (d dummyTestDeps) WriteProfileTo(string, io.Writer, int) error { return nil }
 func (f dummyTestDeps) ImportPath() string                          { return "" }
+func (f dummyTestDeps) SetPanicOnExit0(v bool)                      {}
 
 // FlushProfiles flushes test profiles to disk. It works by build and executing
 // a dummy list of 1 test. This is to ensure we execute the M.after() function


### PR DESCRIPTION
Go 1.16 added the `SetPanicOnExit0(bool)` to the `TestDeps` interface. This adds a corresponding function to `dummyTestDeps` to make things work on go-1.16.

